### PR TITLE
Fix adding resource directory path

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -338,6 +338,7 @@ fn main() {
 
     let (ref mut ctx, ref mut event_loop) = ContextBuilder::new("ggez/specs", "Fudance")
         .conf(c)
+        .add_resource_path(resource_dir)
         .build()
         .unwrap();
 


### PR DESCRIPTION
I got a error complaining not finding "ship.png" file in resource directory. It seems project resource directory is not recognized by GGEZ. I found the solution from a GGEZ example and fixed the problem for me.